### PR TITLE
Minor update to Rock Paper Scissors

### DIFF
--- a/PythonRockPaperScissorGame/rockpaperscissorgame.py
+++ b/PythonRockPaperScissorGame/rockpaperscissorgame.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import random as r
 
 def zues(input1):


### PR DESCRIPTION
Without calling `python` or `python3`, and just run the file as `./rockpaperscissorgame.py`, it should route to Python 3 and run the script. ¯\_(ツ)_/¯

Refers to #27 